### PR TITLE
Fix to load new themes

### DIFF
--- a/src/connectStyle.js
+++ b/src/connectStyle.js
@@ -269,17 +269,11 @@ export default (componentStyleName, componentStyle = {}, mapPropsToStyleNames, o
       }
 
       getOrSetStylesInCache(context, props, styleNames, path) {
-        if(themeCache && themeCache[path.join('>')]) {
-          // console.log('**************');
-          
-          return themeCache[path.join('>')];
-        } else {
-          resolvedStyle = this.resolveStyle(context, props, styleNames);
-          if(Object.keys(themeCache).length < 10000) {
-            themeCache[path.join('>')] = resolvedStyle;
-          }
-          return resolvedStyle;
+        resolvedStyle = this.resolveStyle(context, props, styleNames);
+        if(Object.keys(themeCache).length < 10000) {
+          themeCache[path.join('>')] = resolvedStyle;
         }
+        return resolvedStyle;
       }
 
       resolveStyle(context, props, styleNames) {


### PR DESCRIPTION
themeCache would cache previously used styles even if the theme was changed. With this change, styles are recalculated from the top but parent lookups will still be fetched from the cache as before.