### PR TITLE
Add function to clear the theme cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import connectStyle from "./src/connectStyle";
+import connectStyle, { clearThemeCache } from "./src/connectStyle";
 import { INCLUDE } from "./src/resolveIncludes";
 import StyleProvider from "./src/StyleProvider";
 import Theme, { ThemeShape } from "./src/Theme";
@@ -6,6 +6,7 @@ import { createVariations, createSharedStyle } from "./src/addons";
 
 export {
   connectStyle,
+  clearThemeCache,
   INCLUDE,
   StyleProvider,
   Theme,

--- a/src/connectStyle.js
+++ b/src/connectStyle.js
@@ -8,7 +8,15 @@ import { StyleSheet } from "react-native";
 import Theme, { ThemeShape } from "./Theme";
 import { resolveComponentStyle } from "./resolveComponentStyle";
 
-const themeCache = {};
+let themeCache = {};
+
+/**
+ * clear theme cache
+ * @export
+ */
+export function clearThemeCache() {
+  themeCache = {};
+}
 
 /**
  * Formats and throws an error when connecting component style with the theme.


### PR DESCRIPTION
When the user needs to switch topics can manually clear the local theme cache, no effect when repairing the theme switch

fix  native-base [910](https://github.com/GeekyAnts/NativeBase/issues/910)

```js
import { clearThemeCache } from 'native-base-shoutem-theme';

export function toggleTheme() {
  clearThemeCache();
 // save theme to redux
 // dispatch(...)
}
```